### PR TITLE
Connect to package.elm-lang.org with HTTPS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const http = require('http');
+const http = require('https');
 const table = require('text-table');
 const clc = require('cli-color');
 
@@ -16,7 +16,7 @@ catch (e) {
   process.exit(1);
 }
 
-fetch("http://package.elm-lang.org/all-packages")
+fetch("https://package.elm-lang.org/all-packages")
   .then(data => {
     let parsedJson;
 


### PR DESCRIPTION
Now that the site redirects HTTP requests to HTTPS, this elm-outdated is failing to parse the redirect body as JSON:

```
$ elm-outdated
SyntaxError: Unexpected token < in JSON at position 0
    at JSON.parse (<anonymous>)
    at IncomingMessage.res.on (/Users/kyank/.asdf/installs/nodejs/9.11.1/.npm/lib/node_modules/elm-outdated/index.js:78:24)
    at IncomingMessage.emit (events.js:185:15)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:178:19)
```